### PR TITLE
Refactor & restyle form block containers

### DIFF
--- a/core/src/main/resources/lib/form/optionalBlock.jelly
+++ b/core/src/main/resources/lib/form/optionalBlock.jelly
@@ -66,22 +66,24 @@ THE SOFTWARE.
 
   <j:choose>
     <j:when test="${attrs.title!=null}">
-      <div class="help-sibling tr optional-block-start row-group-start ${attrs.inline?'':'row-set-start'}" hasHelp="${attrs.help!=null}"><!-- this ID marks the beginning -->
-        <div colspan="3">
-          <f:checkbox name="${attrs.name}" class="optional-block-control block-control" onclick="javascript:updateOptionalBlock(this,true)"
-                      negative="${attrs.negative}" checked="${attrs.checked}" field="${attrs.field}" title="${title}" />
-          <f:helpLink url="${attrs.help}" featureName="${title}"/>
+      <div class="optionalBlock-container">
+        <div class="help-sibling tr optional-block-start row-group-start ${attrs.inline?'':'row-set-start'}" hasHelp="${attrs.help!=null}"><!-- this ID marks the beginning -->
+          <div colspan="3">
+            <f:checkbox name="${attrs.name}" class="optional-block-control block-control" onclick="javascript:updateOptionalBlock(this,true)"
+                        negative="${attrs.negative}" checked="${attrs.checked}" field="${attrs.field}" title="${title}" />
+            <f:helpLink url="${attrs.help}" featureName="${title}"/>
+          </div>
         </div>
+        <j:if test="${attrs.help!=null}">
+          <f:helpArea />
+        </j:if>
+        <div class="rowvg-start tr"></div>
+        <div class="form-container tr">
+          <d:invokeBody />
+        </div>
+        <!-- end marker -->
+        <div class="tr ${attrs.inline?'':'row-set-end'} rowvg-end optional-block-end row-group-end"></div>
       </div>
-      <j:if test="${attrs.help!=null}">
-        <f:helpArea />
-      </j:if>
-      <div class="rowvg-start tr"></div>
-      <div class="container tr">
-        <d:invokeBody />
-      </div>
-      <!-- end marker -->
-      <div class="tr ${attrs.inline?'':'row-set-end'} rowvg-end optional-block-end row-group-end"></div>
     </j:when>
 
     <j:otherwise>

--- a/core/src/main/resources/lib/form/radioBlock.jelly
+++ b/core/src/main/resources/lib/form/radioBlock.jelly
@@ -54,27 +54,29 @@ THE SOFTWARE.
 
   <st:adjunct includes="lib.form.radioBlock.radioBlock"/>
 
-  <div class="tr help-sibling radio-block-start row-group-start ${attrs.inline?'':'row-set-start'}" hasHelp="${attrs.help!=null}"><!-- this ID marks the beginning -->
-    <div colspan="3">
-      <label>
-        <input type="radio"
-               name="${name}"
-               value="${value}"
-               class="radio-block-control block-control"
-               checked="${checked ? 'true' : null}"
-               disabled="${readOnlyMode ? 'true' : null}"
-        />
-        ${title}
-      </label>
-      <f:helpLink url="${help}" featureName="${title}" />
+  <div class="radioBlock-container">
+    <div class="tr help-sibling radio-block-start row-group-start ${attrs.inline?'':'row-set-start'}" hasHelp="${attrs.help!=null}"><!-- this ID marks the beginning -->
+      <div colspan="3">
+        <label>
+          <input type="radio"
+                 name="${name}"
+                 value="${value}"
+                 class="radio-block-control block-control"
+                 checked="${checked ? 'true' : null}"
+                 disabled="${readOnlyMode ? 'true' : null}"
+          />
+          ${title}
+        </label>
+        <f:helpLink url="${help}" featureName="${title}" />
+      </div>
     </div>
+    <j:if test="${attrs.help!=null}">
+      <f:helpArea />
+    </j:if>
+    <div class="form-container tr">
+      <d:invokeBody />
+    </div>
+    <!-- end marker -->
+    <div class="tr ${attrs.inline?'':'row-set-end'} radio-block-end row-group-end" style="display:none"></div>
   </div>
-  <j:if test="${attrs.help!=null}">
-    <f:helpArea />
-  </j:if>
-  <div class="container tr">
-    <d:invokeBody />
-  </div>
-  <!-- end marker -->
-  <div class="tr ${attrs.inline?'':'row-set-end'} radio-block-end row-group-end" style="display:none"></div>
 </j:jelly>

--- a/core/src/main/resources/lib/form/rowSet.jelly
+++ b/core/src/main/resources/lib/form/rowSet.jelly
@@ -37,17 +37,19 @@ THE SOFTWARE.
     </st:attribute>
   </st:documentation>
 
-  <j:choose>
-    <j:when test="${attrs.ref==null and attrs.name==null}">
-      <!-- noop -->
-      <d:invokeBody />
-    </j:when>
-    <j:otherwise>
-      <div ref="${attrs.ref}" class="row-set-start row-group-start tr" style="display:none" name="${attrs.name}"></div>
-      <div class="container tr">
+  <div class="rowSet-container">
+    <j:choose>
+      <j:when test="${attrs.ref==null and attrs.name==null}">
+        <!-- noop -->
         <d:invokeBody />
-      </div>
-      <div class="row-set-end row-group-end tr"></div>
-    </j:otherwise>
-  </j:choose>
+      </j:when>
+      <j:otherwise>
+        <div ref="${attrs.ref}" class="row-set-start row-group-start tr" style="display:none" name="${attrs.name}"></div>
+        <div class="form-container tr">
+          <d:invokeBody />
+        </div>
+        <div class="row-set-end row-group-end tr"></div>
+      </j:otherwise>
+    </j:choose>
+  </div>
 </j:jelly>

--- a/war/src/main/less/abstracts/colors.less
+++ b/war/src/main/less/abstracts/colors.less
@@ -1,3 +1,5 @@
+@color-primary: #0587d4;
+
 // Page header colors
 @logo-bg: white;
 @brand-link-color: #4d545d;
@@ -6,7 +8,7 @@
 @header-link-outline: #3FB3F7;
 @search-input-color: @brand-link-color;
 @search-background: white;
-@search-box-completion-bg: #0587d4;
+@search-box-completion-bg: @color-primary;
 @search-box-shadow: 0 1px 7px 0 rgba(0,0,0,0.3);
 
 // Header classic colors
@@ -15,7 +17,7 @@
 @header-link-bg-classic-active: lighten(@header-bg-classic, 20%);
 
 // Header new UI colors
-@header-bg-v2: #0587d4;
+@header-bg-v2: @color-primary;
 @brand-link-color-hover-v2: #0B6AA2;
 @brand-link-color-active-v2: #095683;
 @header-link-bg-hover-v2: #0B6AA2;

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1412,6 +1412,12 @@ TABLE.fingerprint-in-build TD {
 
 .repeated-chunk {
     border: 2px dashed transparent;
+    // border-color: red;
+    border-color: #f0f0f0;
+    padding: 0.5em;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+    padding-left: 1.5rem;
 }
 
 .repeated-chunk.hover {
@@ -1465,6 +1471,10 @@ DIV.to-be-removed { display: none; }
   margin-left: 1rem;
   border-left: 1px solid @color-primary;
   padding-left: 1rem;
+}
+
+.dropdownList-container {
+  padding: 1rem 0 1rem 1.5rem;
 }
 
 .row-set-end { display: none; }
@@ -1555,10 +1565,16 @@ TEXTAREA.rich-editor {
     padding-left: 20px;
 }
 
-.hetero-list-container.with-drag-drop .repeated-chunk {
+.hetero-list-container.with-drag-drop .repeated-chunk,
+.repeated-container.with-drag-drop .repeated-chunk {
     padding: 0.5em;
     margin-top: 0.5em;
     margin-bottom: 0.5em;
+    padding-left: 1.5rem;
+}
+.hetero-list-container.with-drag-drop .repeated-chunk .dd-handle,
+.repeated-container.with-drag-drop .repeated-chunk .dd-handle {
+  margin-left: -1.25rem;
 }
 
 

--- a/war/src/main/less/base/style.less
+++ b/war/src/main/less/base/style.less
@@ -1456,6 +1456,17 @@ DIV.to-be-removed { display: none; }
 
 /* ========================= Other form related CSS ========================= */
 
+.form-container {
+  max-width: 100%;
+}
+
+.optionalBlock-container >.form-container,
+.radioBlock-container >.form-container {
+  margin-left: 1rem;
+  border-left: 1px solid @color-primary;
+  padding-left: 1rem;
+}
+
 .row-set-end { display: none; }
 
 /* ========================= Yahoo UI style adjustments ========================= */

--- a/war/src/main/webapp/css/responsive-grid.css
+++ b/war/src/main/webapp/css/responsive-grid.css
@@ -34,17 +34,17 @@ h1.build-caption.page-headline {
 }
 @media (min-width: 768px) {
   .container {
-    width: 100%;
+    width: 750px;
   }
 }
 @media (min-width: 992px) {
   .container {
-    width: 100%;
+    width: 970px;
   }
 }
 @media (min-width: 1200px) {
   .container {
-    width: 100%;
+    width: 1170px;
   }
 }
 .container-fluid {
@@ -1275,7 +1275,7 @@ h1.build-caption.page-headline {
  */
 @media (min-width: 1800px) {
   .container {
-    width: 100%
+    width: 1760px;
   }
 }
 .col-xlg-1, .col-xlg-2, .col-xlg-3, .col-xlg-4, .col-xlg-5, .col-xlg-6, .col-xlg-7, .col-xlg-8, .col-xlg-9, .col-xlg-10, .col-xlg-11, .col-xlg-12, .col-xlg-13, .col-xlg-14, .col-xlg-15, .col-xlg-16, .col-xlg-17, .col-xlg-18, .col-xlg-19, .col-xlg-20, .col-xlg-21, .col-xlg-22, .col-xlg-23, .col-xlg-24 {


### PR DESCRIPTION
I have tried to edit your branch directly but I get a 403 error when doing `git push`

In this PR I undid the `.container` change, and created different containers for rowSet, optionalBlock and radioBlock. I also added some style for optionalBlock and radioBlock (see screenshots).

I also added some temporary/POC styles for repeatable & hetero list items. It is not yet 100% there but I'd like to gather some input.

<details>
<summary>Optional & radio block screenshots</summary>
Peek at a new DOM tree, lesser number of top-level rows
<img width="628" alt="Captura de pantalla 2020-04-04 a las 13 54 47" src="https://user-images.githubusercontent.com/5738588/78450623-40023780-7680-11ea-90ac-e95c3fd755b4.png">

Optional block
<img width="844" alt="Captura de pantalla 2020-04-04 a las 13 14 19" src="https://user-images.githubusercontent.com/5738588/78450639-5a3c1580-7680-11ea-8def-a2d88f3bbc56.png">

Radio block
<img width="1412" alt="Captura de pantalla 2020-04-04 a las 13 14 59" src="https://user-images.githubusercontent.com/5738588/78450645-645e1400-7680-11ea-815a-f8a1fa31827f.png">
</details>

<details>
<summary>Repeatable nesting screenshots (still not satisfied with these)</summary>

<img width="985" alt="Captura de pantalla 2020-04-04 a las 13 43 19" src="https://user-images.githubusercontent.com/5738588/78450681-a8e9af80-7680-11ea-8283-185af9a04c07.png">

<img width="1025" alt="Captura de pantalla 2020-04-04 a las 13 43 24" src="https://user-images.githubusercontent.com/5738588/78450670-91aac200-7680-11ea-8e2b-cc744593856c.png">


</details>